### PR TITLE
Add kelvin datasource

### DIFF
--- a/vector-configs/sinks/datadog.toml
+++ b/vector-configs/sinks/datadog.toml
@@ -12,6 +12,9 @@ source = '''
   if .service == "lun-backend" {
     .ddsource = "go"
   }
+  if .service == "lun-kelvin" {
+    .ddsource = "kelvin"
+  }
   .hostname = .fly.host
 '''
 


### PR DESCRIPTION
Sets Kelvin datasource.

Currently all logs from Kelvin has source=undefined.

<img width="744" alt="image" src="https://github.com/lun-energy/fly-log-shipper/assets/45588799/eea4b3a1-9ef0-4045-a9ab-93924d9efa4f">

We want to set this so that we can set up a filter to initiate a log parsing pipeline 